### PR TITLE
Update any-db dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "test": "grunt nodeunit"
   },
   "dependencies": {
-    "any-db": ">0",
+    "any-db": "0.x.x",
     "grunt": "~0.4.1",
     "pg": ">0"
   },


### PR DESCRIPTION
Hi, I'm the author of any-db, and I will soon be (re-)publishing a new version of any-db that will break backwards compatibility*. If you continue to rely on an unbounded version range, that will break your package as well, so I thought I'd give you a heads up.
- \- The new version will require libraries to declare any-db as a peerDependency, and end-users (those who actually decide what database to connect to) will depend on any-db-{adapter}
